### PR TITLE
Altered db schema for specialties & phone number

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,13 +1,5 @@
 import { sql } from "drizzle-orm";
-import {
-  pgTable,
-  integer,
-  text,
-  jsonb,
-  serial,
-  timestamp,
-  bigint,
-} from "drizzle-orm/pg-core";
+import { integer, pgTable, serial, text, timestamp, varchar } from "drizzle-orm/pg-core";
 
 const advocates = pgTable("advocates", {
   id: serial("id").primaryKey(),
@@ -15,9 +7,11 @@ const advocates = pgTable("advocates", {
   lastName: text("last_name").notNull(),
   city: text("city").notNull(),
   degree: text("degree").notNull(),
-  specialties: jsonb("payload").default([]).notNull(),
+  specialties: text("specialties").array().default([]).notNull(),
   yearsOfExperience: integer("years_of_experience").notNull(),
-  phoneNumber: bigint("phone_number", { mode: "number" }).notNull(),
+  // Based on https://www.mayerdan.com/programming/2017/06/26/db_phone_types &
+	// https://github.com/google/libphonenumber/blob/d89d07b8dabd6b6694d55b8f17319e5caa23ef18/FALSEHOODS.md
+	phoneNumber: varchar("phone_number", { length: 18 }).notNull(),
   createdAt: timestamp("created_at").default(sql`CURRENT_TIMESTAMP`),
 });
 

--- a/src/db/seed/advocates.ts
+++ b/src/db/seed/advocates.ts
@@ -45,7 +45,7 @@ const advocateData = [
     degree: "MD",
     specialties: specialties.slice(...randomSpecialty()),
     yearsOfExperience: 10,
-    phoneNumber: 5551234567,
+    phoneNumber: "5551234567",
   },
   {
     firstName: "Jane",
@@ -54,7 +54,7 @@ const advocateData = [
     degree: "PhD",
     specialties: specialties.slice(...randomSpecialty()),
     yearsOfExperience: 8,
-    phoneNumber: 5559876543,
+    phoneNumber: "5559876543",
   },
   {
     firstName: "Alice",
@@ -63,7 +63,7 @@ const advocateData = [
     degree: "MSW",
     specialties: specialties.slice(...randomSpecialty()),
     yearsOfExperience: 5,
-    phoneNumber: 5554567890,
+    phoneNumber: "5554567890",
   },
   {
     firstName: "Michael",
@@ -72,7 +72,7 @@ const advocateData = [
     degree: "MD",
     specialties: specialties.slice(...randomSpecialty()),
     yearsOfExperience: 12,
-    phoneNumber: 5556543210,
+    phoneNumber: "5556543210",
   },
   {
     firstName: "Emily",
@@ -81,7 +81,7 @@ const advocateData = [
     degree: "PhD",
     specialties: specialties.slice(...randomSpecialty()),
     yearsOfExperience: 7,
-    phoneNumber: 5553210987,
+    phoneNumber: "5553210987",
   },
   {
     firstName: "Chris",
@@ -90,7 +90,7 @@ const advocateData = [
     degree: "MSW",
     specialties: specialties.slice(...randomSpecialty()),
     yearsOfExperience: 9,
-    phoneNumber: 5557890123,
+    phoneNumber: "5557890123",
   },
   {
     firstName: "Jessica",
@@ -99,7 +99,7 @@ const advocateData = [
     degree: "MD",
     specialties: specialties.slice(...randomSpecialty()),
     yearsOfExperience: 11,
-    phoneNumber: 5554561234,
+    phoneNumber: "5554561234",
   },
   {
     firstName: "David",
@@ -108,7 +108,7 @@ const advocateData = [
     degree: "PhD",
     specialties: specialties.slice(...randomSpecialty()),
     yearsOfExperience: 6,
-    phoneNumber: 5557896543,
+    phoneNumber: "5557896543",
   },
   {
     firstName: "Laura",
@@ -117,7 +117,7 @@ const advocateData = [
     degree: "MSW",
     specialties: specialties.slice(...randomSpecialty()),
     yearsOfExperience: 4,
-    phoneNumber: 5550123456,
+    phoneNumber: "5550123456",
   },
   {
     firstName: "Daniel",
@@ -126,7 +126,7 @@ const advocateData = [
     degree: "MD",
     specialties: specialties.slice(...randomSpecialty()),
     yearsOfExperience: 13,
-    phoneNumber: 5553217654,
+    phoneNumber: "5553217654",
   },
   {
     firstName: "Sarah",
@@ -135,7 +135,7 @@ const advocateData = [
     degree: "PhD",
     specialties: specialties.slice(...randomSpecialty()),
     yearsOfExperience: 10,
-    phoneNumber: 5551238765,
+    phoneNumber: "5551238765",
   },
   {
     firstName: "James",
@@ -144,7 +144,7 @@ const advocateData = [
     degree: "MSW",
     specialties: specialties.slice(...randomSpecialty()),
     yearsOfExperience: 5,
-    phoneNumber: 5556540987,
+    phoneNumber: "5556540987",
   },
   {
     firstName: "Megan",
@@ -153,7 +153,7 @@ const advocateData = [
     degree: "MD",
     specialties: specialties.slice(...randomSpecialty()),
     yearsOfExperience: 14,
-    phoneNumber: 5559873456,
+    phoneNumber: "5559873456",
   },
   {
     firstName: "Joshua",
@@ -162,7 +162,7 @@ const advocateData = [
     degree: "PhD",
     specialties: specialties.slice(...randomSpecialty()),
     yearsOfExperience: 9,
-    phoneNumber: 5556781234,
+    phoneNumber: "5556781234",
   },
   {
     firstName: "Amanda",
@@ -171,7 +171,7 @@ const advocateData = [
     degree: "MSW",
     specialties: specialties.slice(...randomSpecialty()),
     yearsOfExperience: 3,
-    phoneNumber: 5559872345,
+    phoneNumber: "5559872345",
   },
 ];
 


### PR DESCRIPTION
### TL;DR

Changed phone number storage and changed specialties from JSON to text array in the advocates schema.

### What changed?

- Changed `phoneNumber` field from `bigint` to `varchar(15)` - Modified `specialties` field from `jsonb("payload")` to `text("specialties").array()`
- Updated seed data to use string phone numbers instead of numeric values
- Cleaned up imports in the schema file

### Why make this change?

The phone number change follows recommended practices for storing phone numbers. Using a text array for specialties more closely aligns with the seed data.