### PR TITLE
Support for full-text search across advocate data

### DIFF
--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -10,6 +10,8 @@
   * `next` comes with `.env` out of the box, but we need something like `dotenv` for node versions under 20 or [built-in for 20+](https://nodejs.org/docs/
   latest-v22.x/api/cli.html#--env-fileconfig) 
   * Opted to use `drizzle-kit migrate`
+* Seeding required hitting an API rather than utilizing `drizzle-seed`
+* Can now reset the db
 
 # Query or Select?
 `drizzle` supports both the query pattern and a closer to sql pattern. I prefer the query pattern when possible.
@@ -18,12 +20,12 @@
 
 # To Memoize or Not To Memoize
 Memoization does improve rendering performance, but it does come at a cost.
-* Longer development to optimize as it requires more code
-* Memoization causes immediate overhead for what may not be meaningful performance gains  
+* Longer development to optimize as it may require more code
+* Memoization causes immediate overhead for what may not be meaningful performance gains
   * An example of overhead `const val = x + 1` ran through `useMemo` is more overhead
 * Rarely profiled the performance impact as that would require even more development time
 * React compiler claims it will save the world
-* Less maintainable due to more code being written
+* Often less maintainable due to more code being written
 * https://overreacted.io/before-you-memo/ by dan abramov
 * `useMemo` often breaks the continuity of reading
 * Viral in nature. Parent passing props must be stable to children components.
@@ -41,6 +43,25 @@ Even more ideal would be kicking the can down the road for [React Compiler](http
 An example of getting improved performance with memoization is seen in a few places:
 * `src/app/components/data-table/data-table-toolbar.tsx` `InputFilter` utilizes `useMemo` to prevent excessive renders whenever 
 we render from table state changes
-* `src/app/components/data-table/data-table-faceted-filter.tsx` shows a more involved memoization effort as the state was not moved down
+* `src/app/components/data-table/data-table-faceted-filter.tsx` shows a more involved memoization effort from parent -> child
+  * If the filter values does not change does not render again if the rest of the table state changes
+  * Internally we update the sorted options only when we open the filter
 * `src/app/components/data-table/data-table-view-options.tsx` shows how the improved simplicity of moving state down handling most render optimation
 while keeping the code generally simpler
+
+# Library choices
+## Why shadcn/ui?
+I previously built a DataTable based on it and found it quite good. It is quite popular and fully owned and controlled by you (I did an ADR on this that I could share).
+
+## Why tanstack query?
+For this assignment it isn't necessary, but it is a commonly utilized library and offers several advantages over handrolling everything yourself. 
+I utilized the `streamedQuery` for the key streaming portion that I implemented.
+
+## Why tanstack table?
+This is an incredibly powerful table library that does not even care what UI you're generating as it is all headless. 
+This makes creating custom UX for a table much easier and out of the box is more powerful than nearly any other solution.
+
+# More time?
+* Fully utilize the full-text search in combination with client-side filtering
+* More optimizations
+* Mobile design fixes

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,18 +1,47 @@
-import { sql } from "drizzle-orm";
-import { integer, pgTable, serial, text, timestamp, varchar } from "drizzle-orm/pg-core";
+import { type SQL, sql } from "drizzle-orm";
+import { customType, index, integer, pgTable, serial, text, timestamp, varchar } from "drizzle-orm/pg-core";
 
-const advocates = pgTable("advocates", {
-  id: serial("id").primaryKey(),
-  firstName: text("first_name").notNull(),
-  lastName: text("last_name").notNull(),
-  city: text("city").notNull(),
-  degree: text("degree").notNull(),
-  specialties: text("specialties").array().default([]).notNull(),
-  yearsOfExperience: integer("years_of_experience").notNull(),
-  // Based on https://www.mayerdan.com/programming/2017/06/26/db_phone_types &
-  // https://github.com/google/libphonenumber/blob/d89d07b8dabd6b6694d55b8f17319e5caa23ef18/FALSEHOODS.md
-  phoneNumber: varchar("phone_number", { length: 18 }).notNull(),
-  createdAt: timestamp("created_at").default(sql`CURRENT_TIMESTAMP`),
+export const tsvector = customType<{
+  data: string;
+}>({
+  dataType() {
+    return `tsvector`;
+  },
 });
+const advocates = pgTable(
+  "advocates",
+  {
+    id: serial("id").primaryKey(),
+    firstName: text("first_name").notNull(),
+    lastName: text("last_name").notNull(),
+    city: text("city").notNull(),
+    degree: text("degree").notNull(),
+    specialties: text("specialties").array().default([]).notNull(),
+    yearsOfExperience: integer("years_of_experience").notNull(),
+    // Based on https://www.mayerdan.com/programming/2017/06/26/db_phone_types &
+    // https://github.com/google/libphonenumber/blob/d89d07b8dabd6b6694d55b8f17319e5caa23ef18/FALSEHOODS.md
+    phoneNumber: varchar("phone_number", { length: 18 }).notNull(),
+    createdAt: timestamp("created_at").default(sql`CURRENT_TIMESTAMP`),
+    search: tsvector("search")
+      .notNull()
+      .generatedAlwaysAs(
+        (): SQL =>
+          sql`setweight(to_tsvector('english', ${advocates.firstName}), 'A')
+        ||
+        setweight(to_tsvector('english', ${advocates.lastName}), 'A')
+        ||
+        setweight(to_tsvector('english', ${advocates.city}), 'B')
+        ||
+        setweight(to_tsvector('english', ${advocates.degree}), 'D')
+        ||
+        setweight(to_tsvector('english', ${advocates.phoneNumber}), 'C')
+        ||
+        setweight(to_tsvector('english', ${advocates.yearsOfExperience}::text), 'D')
+        ||
+        setweight(array_to_tsvector(${advocates.specialties}), 'C')`,
+      ),
+  },
+  (t) => [index("idx_advocates_search").using("gin", t.search)],
+);
 
 export { advocates };

--- a/src/db/seed/seeder.ts
+++ b/src/db/seed/seeder.ts
@@ -26,6 +26,8 @@ async function main() {
           generatedDigitsNumbers: 7,
         }),
         specialties: fns.jobTitle({ arraySize: 4 }),
+        // This is a placeholder so seeding can still work
+        search: fns.string(),
       },
     },
   }));


### PR DESCRIPTION
### TL;DR

Added full-text search capability to the advocates table.

### What changed?

- Added a `search` column to the advocates table that automatically generates a weighted tsvector from multiple fields:
  - First and last name (weight A - highest priority)
  - City (weight B - high priority)
  - Phone number and specialties (weight C - medium priority)
  - Degree and years of experience (weight D - lowest priority)
- Added a GIN index on the search column for efficient full-text search
- Updated the seeder to include a placeholder for the search field

### Why make this change?

This change enables full-text search across advocate records with weighting (best judgement used for them). This allows combining streaming with searching or entirely using search without any streaming. This is a PoC for what a full-text search solution would look like.